### PR TITLE
MTTL-650 Modify Response Object to show Tenure status

### DIFF
--- a/PersonApi.Tests/V1/Domain/TenureTests.cs
+++ b/PersonApi.Tests/V1/Domain/TenureTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Globalization;
+using FluentAssertions;
+using PersonApi.V1.Domain;
+using Xunit;
+
+namespace PersonApi.Tests.V1.Domain
+{
+    public class TenureTests
+    {
+        private Tenure _classUnderTest;
+
+        public TenureTests()
+        {
+            _classUnderTest = new Tenure();
+        }
+
+        [Fact]
+        public void GivenATenureWhenEndDateIsNullThenIsActiveShouldBeTrue()
+        {
+            // given + when + then
+            _classUnderTest.IsActive.Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenATenureWhenEndDateIsGreaterThanCurrentDateThenIsActiveShouldBeTrue()
+        {
+            // given
+            _classUnderTest.EndDate = DateTime.Now.AddDays(1).ToShortDateString();
+            
+            // when + then
+            _classUnderTest.IsActive.Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenATenureWhenEndDateIsLessThanCurrentDateThenIsActiveShouldBeFalse()
+        {
+            // given
+            _classUnderTest.EndDate = DateTime.Now.AddDays(-1).ToShortDateString();
+
+            // when + then
+            _classUnderTest.IsActive.Should().BeFalse();
+        }
+    }
+}

--- a/PersonApi.Tests/V1/Domain/TenureTests.cs
+++ b/PersonApi.Tests/V1/Domain/TenureTests.cs
@@ -27,7 +27,7 @@ namespace PersonApi.Tests.V1.Domain
         {
             // given
             _classUnderTest.EndDate = DateTime.Now.AddDays(1).ToShortDateString();
-            
+
             // when + then
             _classUnderTest.IsActive.Should().BeTrue();
         }

--- a/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
+++ b/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
@@ -2,7 +2,9 @@ using Amazon.DynamoDBv2.DataModel;
 using AutoFixture;
 using PersonApi.V1.Infrastructure;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using PersonApi.V1.Domain;
 
 namespace PersonApi.Tests.V1.E2ETests.Fixtures
 {
@@ -45,6 +47,7 @@ namespace PersonApi.Tests.V1.E2ETests.Fixtures
                                      .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                      .Create();
 
+                person.Tenures = new List<Tenure>(new[] {person.Tenures.First()});
                 person.Tenures.First().EndDate = DateTime.UtcNow.AddYears(-30).ToShortDateString();
 
                 _dbContext.SaveAsync<PersonDbEntity>(person).GetAwaiter().GetResult();

--- a/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
+++ b/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
@@ -2,6 +2,7 @@ using Amazon.DynamoDBv2.DataModel;
 using AutoFixture;
 using PersonApi.V1.Infrastructure;
 using System;
+using System.Linq;
 
 namespace PersonApi.Tests.V1.E2ETests.Fixtures
 {
@@ -43,6 +44,9 @@ namespace PersonApi.Tests.V1.E2ETests.Fixtures
                 var person = _fixture.Build<PersonDbEntity>()
                                      .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                      .Create();
+
+                person.Tenures.First().EndDate = DateTime.UtcNow.AddYears(-30).ToShortDateString();
+
                 _dbContext.SaveAsync<PersonDbEntity>(person).GetAwaiter().GetResult();
                 Person = person;
                 PersonId = person.Id;

--- a/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
+++ b/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
@@ -47,7 +47,7 @@ namespace PersonApi.Tests.V1.E2ETests.Fixtures
                                      .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                      .Create();
 
-                person.Tenures = new List<Tenure>(new[] {person.Tenures.First()});
+                person.Tenures = new List<Tenure>(new[] { person.Tenures.First() });
                 person.Tenures.First().EndDate = DateTime.UtcNow.AddYears(-30).ToShortDateString();
 
                 _dbContext.SaveAsync<PersonDbEntity>(person).GetAwaiter().GetResult();

--- a/PersonApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PersonApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -69,6 +69,7 @@ namespace PersonApi.Tests.V1.Gateways
             var entity = _fixture.Build<Person>()
                                  .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                  .Create();
+            entity.Tenures = new [] { entity.Tenures.First()};
             entity.Tenures.First().EndDate = DateTime.UtcNow.AddYears(-30).ToShortDateString();
 
             var dbEntity = entity.ToDatabase();

--- a/PersonApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PersonApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -69,7 +69,7 @@ namespace PersonApi.Tests.V1.Gateways
             var entity = _fixture.Build<Person>()
                                  .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                  .Create();
-            entity.Tenures = new [] { entity.Tenures.First()};
+            entity.Tenures = new[] { entity.Tenures.First() };
             entity.Tenures.First().EndDate = DateTime.UtcNow.AddYears(-30).ToShortDateString();
 
             var dbEntity = entity.ToDatabase();

--- a/PersonApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PersonApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -9,6 +9,7 @@ using PersonApi.V1.Gateways;
 using PersonApi.V1.Infrastructure;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -68,6 +69,8 @@ namespace PersonApi.Tests.V1.Gateways
             var entity = _fixture.Build<Person>()
                                  .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                  .Create();
+            entity.Tenures.First().EndDate = DateTime.UtcNow.AddYears(-30).ToShortDateString();
+
             var dbEntity = entity.ToDatabase();
 
             await _dynamoDb.SaveAsync(dbEntity).ConfigureAwait(false);

--- a/PersonApi/V1/Domain/Tenure.cs
+++ b/PersonApi/V1/Domain/Tenure.cs
@@ -18,6 +18,6 @@ namespace PersonApi.V1.Domain
 
         public string Uprn { get; set; }
 
-        public bool IsActive => EndDate == null || DateTime.Parse(EndDate) > DateTime.Now;
+        public bool IsActive => EndDate == null || DateTime.Parse(EndDate) > DateTime.UtcNow;
     }
 }

--- a/PersonApi/V1/Domain/Tenure.cs
+++ b/PersonApi/V1/Domain/Tenure.cs
@@ -17,5 +17,7 @@ namespace PersonApi.V1.Domain
         public string Type { get; set; }
 
         public string Uprn { get; set; }
+
+        public bool IsActive => EndDate == null || DateTime.Parse(EndDate) > DateTime.Now;
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-650

## Describe this PR

### *What is the problem we're trying to solve*

In order to see if a tenure is still active, we should check its end date.
To help FE having to calculate this by themselves for every single tenure, we can introduce an extra property 'IsActive' to the response object that the FE can check.

### *What changes have we introduced*

Added a property to the response object

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

