### PR TITLE
Enum values in events as strings

### DIFF
--- a/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
+++ b/PersonApi.Tests/V1/E2ETests/Fixtures/PersonFixture.cs
@@ -78,6 +78,7 @@ namespace PersonApi.Tests.V1.E2ETests.Fixtures
                 var person = _fixture.Build<PersonDbEntity>()
                                      .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-30))
                                      .With(x => x.NationalInsuranceNo, "AA123456C")
+                                     .With(x => x.Title, Title.Mr)
                                      .With(x => x.Tenures, _fixture.Build<Tenure>()
                                               .With(y => y.StartDate, "")
                                               .With(y => y.EndDate, "")
@@ -122,7 +123,8 @@ namespace PersonApi.Tests.V1.E2ETests.Fixtures
             var personRequest = new UpdatePersonRequestObject()
             {
                 FirstName = "Update",
-                Surname = "Updating"
+                Surname = "Updating",
+                Title = Title.Dr
             };
 
             UpdateSnsTopic();

--- a/PersonApi.Tests/V1/E2ETests/Stories/UpdatePersonTests.cs
+++ b/PersonApi.Tests/V1/E2ETests/Stories/UpdatePersonTests.cs
@@ -46,7 +46,7 @@ namespace PersonApi.Tests.V1.E2ETests.Stories
         }
 
         [Fact]
-        public void ServiceReturnsTheRequestedPerson()
+        public void ServiceUpdatesTheRequestedPerson()
         {
             this.Given(g => _personFixture.GivenAPersonAlreadyExistsAndUpdateRequested())
                 .And(g => _personFixture.GivenAUpdatePersonRequest())

--- a/PersonApi/V1/Gateways/PersonSnsGateway.cs
+++ b/PersonApi/V1/Gateways/PersonSnsGateway.cs
@@ -1,9 +1,10 @@
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using PersonApi.V1.Domain;
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace PersonApi.V1.Gateways
@@ -12,16 +13,30 @@ namespace PersonApi.V1.Gateways
     {
         private readonly IAmazonSimpleNotificationService _amazonSimpleNotificationService;
         private readonly IConfiguration _configuration;
+        private readonly JsonSerializerOptions _jsonOptions;
 
         public PersonSnsGateway(IAmazonSimpleNotificationService amazonSimpleNotificationService, IConfiguration configuration)
         {
             _amazonSimpleNotificationService = amazonSimpleNotificationService;
             _configuration = configuration;
+
+            _jsonOptions = CreateJsonOptions();
+        }
+
+        private static JsonSerializerOptions CreateJsonOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+            options.Converters.Add(new JsonStringEnumConverter());
+            return options;
         }
 
         public async Task Publish(PersonSns personSns)
         {
-            string message = JsonConvert.SerializeObject(personSns);
+            string message = JsonSerializer.Serialize(personSns, _jsonOptions);
             var request = new PublishRequest
             {
                 Message = message,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-1017.

## Describe this PR

Any enum values specified in the old/new data in a raised event should be serialised as the string rather than the int value.
