### PR TITLE
Sorted order of tenures in PersonResponseObject.

### DIFF
--- a/PersonApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/PersonApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -71,21 +71,13 @@ namespace PersonApi.Tests.V1.Factories
             response.Tenures.Should().BeEquivalentTo(person.Tenures?.Select(x => ResponseFactory.ToResponse(x)));
         }
 
-
-        // Test that tenures are ordered
-        // Active first - newest to oldest
-        // Inactive - newest to oldest
-
-        // create list of active tenures - random dates
-        // create list of inactive tenures - random dates
-
         [Fact]
-        public void PersonResponseObjectToResponseWhenCalledReturnsTenuresInCorrectOrder()
+        public void PersonResponseObjectToResponseWhenCalledOrdersActiveTenuresBeforeInactiveTenures()
         {
             var numberOfActiveTenures = _random.Next(2, 5);
             var numberOfInactiveTenures = _random.Next(2, 5);
 
-            // create random list of active and inactive tenures
+            // Create list of active and inactive tenures
             var shuffledTenures = CreateListOfShuffledTenures(numberOfActiveTenures, numberOfInactiveTenures);
 
             // mock person
@@ -94,22 +86,50 @@ namespace PersonApi.Tests.V1.Factories
             // call method
             var response = _sut.ToResponse(mockPerson);
 
-            // seperate response into what should be active and inactive tenures
             var responseActiveTenures = response.Tenures.Take(numberOfActiveTenures);
             var responseInactiveTenures = response.Tenures.Skip(numberOfActiveTenures).Take(numberOfInactiveTenures);
-
 
             // assert first half of tenures are active
             responseActiveTenures.Should().OnlyContain(x => x.IsActive == true);
 
             // assert second half of tenures are inactive
             responseInactiveTenures.Should().OnlyContain(x => x.IsActive == false);
+        }
 
-            // assert first half of tenures is in date order
-            responseActiveTenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
+        [Fact]
+        public void PersonResponseObjectToResponseWhenCalledOrdersActiveTenuresByStartDate()
+        {
+            var numberOfActiveTenures = _random.Next(2, 5);
 
-            // assert second half of tenures is in date order
-            responseInactiveTenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
+            // create random list of active tenures
+            var shuffledTenures = CreateListOfShuffledTenures(numberOfActiveTenures, 0);
+
+            // mock person
+            var mockPerson = _fixture.Build<Person>().With(x => x.Tenures, shuffledTenures).Create();
+
+            // call method
+            var response = _sut.ToResponse(mockPerson);
+
+            // assert active tenures are in date order
+            response.Tenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
+        }
+
+        [Fact]
+        public void PersonResponseObjectToResponseWhenCalledOrdersInactiveTenuresByStartDate()
+        {
+            var numberOfInactiveTenures = _random.Next(2, 5);
+
+            // create random list of active tenures
+            var shuffledTenures = CreateListOfShuffledTenures(0, numberOfInactiveTenures);
+
+            // mock person
+            var mockPerson = _fixture.Build<Person>().With(x => x.Tenures, shuffledTenures).Create();
+
+            // call method
+            var response = _sut.ToResponse(mockPerson);
+
+            // assert inactive tenures are in date order
+            response.Tenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
         }
 
         private List<Tenure> CreateListOfShuffledTenures(int numberOfActiveTenures, int numberOfInactiveTenures)

--- a/PersonApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/PersonApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -5,6 +5,7 @@ using PersonApi.V1.Boundary;
 using PersonApi.V1.Domain;
 using PersonApi.V1.Factories;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -15,6 +16,8 @@ namespace PersonApi.Tests.V1.Factories
         private readonly Fixture _fixture = new Fixture();
         private readonly Mock<IApiLinkGenerator> _mockLinkGenerator;
         private readonly ResponseFactory _sut;
+
+        private readonly Random _random = new Random();
 
         public ResponseFactoryTest()
         {
@@ -66,6 +69,79 @@ namespace PersonApi.Tests.V1.Factories
             response.DateOfBirth.Should().Be(ResponseFactory.FormatDateOfBirth(person.DateOfBirth));
             response.PersonTypes.Should().BeEquivalentTo(person.PersonTypes);
             response.Tenures.Should().BeEquivalentTo(person.Tenures?.Select(x => ResponseFactory.ToResponse(x)));
+        }
+
+
+        // Test that tenures are ordered
+        // Active first - newest to oldest
+        // Inactive - newest to oldest
+
+        // create list of active tenures - random dates
+        // create list of inactive tenures - random dates
+
+        [Fact]
+        public void PersonResponseObjectToResponseWhenCalledReturnsTenuresInCorrectOrder()
+        {
+            var numberOfActiveTenures = _random.Next(2, 5);
+            var numberOfInactiveTenures = _random.Next(2, 5);
+
+            // create random list of active and inactive tenures
+            var shuffledTenures = CreateListOfShuffledTenures(numberOfActiveTenures, numberOfInactiveTenures);
+
+            // mock person
+            var mockPerson = _fixture.Build<Person>().With(x => x.Tenures, shuffledTenures).Create();
+
+            // call method
+            var response = _sut.ToResponse(mockPerson);
+
+            // seperate response into what should be active and inactive tenures
+            var responseActiveTenures = response.Tenures.Take(numberOfActiveTenures);
+            var responseInactiveTenures = response.Tenures.Skip(numberOfActiveTenures).Take(numberOfInactiveTenures);
+
+
+            // assert first half of tenures are active
+            responseActiveTenures.Should().OnlyContain(x => x.IsActive == true);
+
+            // assert second half of tenures are inactive
+            responseInactiveTenures.Should().OnlyContain(x => x.IsActive == false);
+
+            // assert first half of tenures is in date order
+            responseActiveTenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
+
+            // assert second half of tenures is in date order
+            responseInactiveTenures.Select(x => DateTime.Parse(x.StartDate)).Should().BeInDescendingOrder();
+        }
+
+        private List<Tenure> CreateListOfShuffledTenures(int numberOfActiveTenures, int numberOfInactiveTenures)
+        {
+            // Tenure.IsActive is readonly. Must set enddate to null or date in past
+            string activeTenureDateValue = null;
+            string inactiveTeunureDateValue = DateTime.UtcNow.AddDays(-7).ToString(); // generate date in past
+
+            // create list of active tenures - random dates
+            var activeTenures = _fixture.Build<Tenure>()
+                .With(x => x.EndDate, activeTenureDateValue)
+                .With(x => x.StartDate, CreateRandomStartDateValue)
+                .CreateMany(numberOfActiveTenures);
+
+            // create list of inactive tenures - random dates
+            var inactiveTenures = _fixture.Build<Tenure>()
+                .With(x => x.EndDate, inactiveTeunureDateValue)
+                .With(x => x.StartDate, CreateRandomStartDateValue)
+                .CreateMany(numberOfInactiveTenures);
+
+            // combine shuffle list
+            var shuffledTenures = activeTenures.Concat(inactiveTenures).OrderBy(item => _random.Next());
+
+            return shuffledTenures.ToList();
+        }
+
+        private string CreateRandomStartDateValue()
+        {
+            // An inactive tenure must have enddate set in past
+            var numberOfDaysInPast = _random.Next(-1000, -1);
+
+            return DateTime.UtcNow.AddDays(numberOfDaysInPast).ToString();
         }
     }
 }

--- a/PersonApi/V1/Factories/ResponseFactory.cs
+++ b/PersonApi/V1/Factories/ResponseFactory.cs
@@ -2,6 +2,7 @@ using PersonApi.V1.Boundary;
 using PersonApi.V1.Boundary.Response;
 using PersonApi.V1.Domain;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PersonApi.V1.Factories
@@ -38,9 +39,27 @@ namespace PersonApi.V1.Factories
                 DateOfBirth = FormatDateOfBirth(domain.DateOfBirth),
                 PersonTypes = domain.PersonTypes,
                 Links = _apiLinkGenerator?.GenerateLinksForPerson(domain),
-                Tenures = domain.Tenures?.Select(x => ToResponse(x)).ToList(),
+                //Tenures = domain.Tenures?.Select(x => ToResponse(x)).ToList(),
+                Tenures = SortTentures(domain.Tenures),
                 Reason = domain.Reason
             };
+        }
+
+        private static List<TenureResponseObject> SortTentures(IEnumerable<Tenure> tenures)
+        {
+            if (tenures == null) return null;
+
+            // 1. Filter and order active tenures - newest to oldest
+            var activeTenures = tenures.Where(x => x.IsActive).OrderByDescending(x => DateTime.Parse(x.StartDate));
+
+            // 2. Filter and order inactive tenures - newest to oldest
+            var inactiveTenures = tenures.Where(x => x.IsActive == false).OrderByDescending(x => DateTime.Parse(x.StartDate));
+
+            // 3. create combined list of all tenures
+            var allTenures = activeTenures.Concat(inactiveTenures);
+
+            // 4. convert all to TenureResponseObject
+            return allTenures.ToList().Select(x => ToResponse(x)).ToList();
         }
 
         public static TenureResponseObject ToResponse(Tenure tenure)

--- a/PersonApi/V1/Factories/ResponseFactory.cs
+++ b/PersonApi/V1/Factories/ResponseFactory.cs
@@ -50,10 +50,24 @@ namespace PersonApi.V1.Factories
             if (tenures == null) return null;
 
             // 1. Filter and order active tenures - newest to oldest
-            var activeTenures = tenures.Where(x => x.IsActive).OrderByDescending(x => DateTime.Parse(x.StartDate));
+            var activeTenures = tenures.Where(x => x.IsActive).OrderByDescending(x =>
+            {
+                DateTime parsedDate;
+
+                if (DateTime.TryParse(x.StartDate, out parsedDate)) return (DateTime?) parsedDate;
+
+                return null;
+            });
 
             // 2. Filter and order inactive tenures - newest to oldest
-            var inactiveTenures = tenures.Where(x => x.IsActive == false).OrderByDescending(x => DateTime.Parse(x.StartDate));
+            var inactiveTenures = tenures.Where(x => x.IsActive == false).OrderByDescending(x =>
+            {
+                DateTime parsedDate;
+
+                if (DateTime.TryParse(x.StartDate, out parsedDate)) return (DateTime?) parsedDate;
+
+                return null;
+            });
 
             // 3. create combined list of all tenures
             var allTenures = activeTenures.Concat(inactiveTenures);

--- a/PersonApi/V1/Factories/ResponseFactory.cs
+++ b/PersonApi/V1/Factories/ResponseFactory.cs
@@ -50,30 +50,25 @@ namespace PersonApi.V1.Factories
             if (tenures == null) return null;
 
             // 1. Filter and order active tenures - newest to oldest
-            var activeTenures = tenures.Where(x => x.IsActive).OrderByDescending(x =>
-            {
-                DateTime parsedDate;
-
-                if (DateTime.TryParse(x.StartDate, out parsedDate)) return (DateTime?) parsedDate;
-
-                return null;
-            });
+            var activeTenures = tenures.Where(x => x.IsActive).OrderByDescending(ParseTenureStartDate);
 
             // 2. Filter and order inactive tenures - newest to oldest
-            var inactiveTenures = tenures.Where(x => x.IsActive == false).OrderByDescending(x =>
-            {
-                DateTime parsedDate;
-
-                if (DateTime.TryParse(x.StartDate, out parsedDate)) return (DateTime?) parsedDate;
-
-                return null;
-            });
+            var inactiveTenures = tenures.Where(x => x.IsActive == false).OrderByDescending(ParseTenureStartDate);
 
             // 3. create combined list of all tenures
             var allTenures = activeTenures.Concat(inactiveTenures);
 
             // 4. convert all to TenureResponseObject
             return allTenures.ToList().Select(x => ToResponse(x)).ToList();
+        }
+
+        private static DateTime? ParseTenureStartDate(Tenure tenure)
+        {
+            DateTime parsedDate;
+
+            if (DateTime.TryParse(tenure.StartDate, out parsedDate)) return (DateTime?) parsedDate;
+
+            return null;
         }
 
         public static TenureResponseObject ToResponse(Tenure tenure)


### PR DESCRIPTION
## Link to JIRA ticket
[Jira ticket](https://hackney.atlassian.net/browse/MTTL-1078)

## Describe this PR
Changed order of Tenures returned in GetPersonByIdAsync controller method.

New Order
=======
- Active tenures - Newest to oldest
- Inactive tenures - Newest to oldest

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly