### PR TITLE
adding quotes around etag and ifmatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ tmp/
 .ionide
 
 testresults/
+*.ncrunchsolution

--- a/PersonApi.Tests/V1/Controllers/PersonApiControllerTests.cs
+++ b/PersonApi.Tests/V1/Controllers/PersonApiControllerTests.cs
@@ -112,7 +112,7 @@ namespace PersonApi.Tests.V1.Controllers
             // Assert
             response.Should().BeOfType(typeof(OkObjectResult));
             _sut.HttpContext.Response.Headers.TryGetValue(HeaderConstants.ETag, out StringValues val).Should().BeTrue();
-            val.First().Should().Be(personResponse.VersionNumber.ToString());
+            val.First().Should().Be($"\"{personResponse.VersionNumber.ToString()}\"");
             (response as OkObjectResult).Value.Should().BeEquivalentTo(_responseFactory.ToResponse(personResponse));
         }
 

--- a/PersonApi.Tests/V1/Controllers/PersonApiControllerTests.cs
+++ b/PersonApi.Tests/V1/Controllers/PersonApiControllerTests.cs
@@ -222,7 +222,7 @@ namespace PersonApi.Tests.V1.Controllers
         {
             // Arrange
             var query = ConstructQuery();
-            _requestHeaders.Add(HeaderConstants.IfMatch, new StringValues(expected?.ToString()));
+            _requestHeaders.Add(HeaderConstants.IfMatch, $"\"{new StringValues(expected?.ToString())}\"");
 
             var exception = new VersionNumberConflictException(expected, actual);
             _mockUpdatePersonUseCase.Setup(x => x.ExecuteAsync(It.IsAny<UpdatePersonRequestObject>(), RequestBodyText, It.IsAny<Token>(), query, expected))

--- a/PersonApi.Tests/V1/E2ETests/Steps/GetPersonSteps.cs
+++ b/PersonApi.Tests/V1/E2ETests/Steps/GetPersonSteps.cs
@@ -32,7 +32,7 @@ namespace PersonApi.Tests.V1.E2ETests.Steps
 
             var eTagHeaders = _lastResponse.Headers.GetValues(HeaderConstants.ETag);
             eTagHeaders.Count().Should().Be(1);
-            eTagHeaders.First().Should().Be(expectedPerson.VersionNumber.ToString());
+            eTagHeaders.First().Should().Be($"\"{expectedPerson.VersionNumber.ToString()}\"");
 
             apiPerson.DateOfBirth.Should().Be(ResponseFactory.FormatDateOfBirth(expectedPerson.DateOfBirth));
             apiPerson.FirstName.Should().Be(expectedPerson.FirstName);

--- a/PersonApi.Tests/V1/E2ETests/Steps/UpdatePersonStep.cs
+++ b/PersonApi.Tests/V1/E2ETests/Steps/UpdatePersonStep.cs
@@ -45,7 +45,7 @@ namespace PersonApi.Tests.V1.E2ETests.Steps
             message.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
             message.Method = HttpMethod.Patch;
             message.Headers.Add("Authorization", token);
-            message.Headers.TryAddWithoutValidation(HeaderConstants.IfMatch, ifMatch?.ToString());
+            message.Headers.TryAddWithoutValidation(HeaderConstants.IfMatch, $"\"{ifMatch?.ToString()}\"");
 
             _httpClient.DefaultRequestHeaders
                 .Accept

--- a/PersonApi.Tests/V2/E2ETests/Steps/PostPersonSteps.cs
+++ b/PersonApi.Tests/V2/E2ETests/Steps/PostPersonSteps.cs
@@ -68,7 +68,7 @@ namespace PersonApi.Tests.V2.E2ETests.Steps
             apiPerson.Should().BeEquivalentTo(new ResponseFactory(null).ToResponse(dbRecord.ToDomain()),
                                               config => config.Excluding(y => y.Links));
             dbRecord.VersionNumber.Should().Be(0);
-            //dbRecord.LastModified.Should().BeCloseTo(DateTime.UtcNow, 1000);
+            dbRecord.LastModified.Should().BeCloseTo(DateTime.UtcNow, 1000);
 
             await personFixture._dbContext.DeleteAsync<PersonDbEntity>(dbRecord.Id).ConfigureAwait(false);
         }

--- a/PersonApi.Tests/V2/E2ETests/Steps/PostPersonSteps.cs
+++ b/PersonApi.Tests/V2/E2ETests/Steps/PostPersonSteps.cs
@@ -68,7 +68,7 @@ namespace PersonApi.Tests.V2.E2ETests.Steps
             apiPerson.Should().BeEquivalentTo(new ResponseFactory(null).ToResponse(dbRecord.ToDomain()),
                                               config => config.Excluding(y => y.Links));
             dbRecord.VersionNumber.Should().Be(0);
-            dbRecord.LastModified.Should().BeCloseTo(DateTime.UtcNow, 1000);
+            //dbRecord.LastModified.Should().BeCloseTo(DateTime.UtcNow, 1000);
 
             await personFixture._dbContext.DeleteAsync<PersonDbEntity>(dbRecord.Id).ConfigureAwait(false);
         }

--- a/PersonApi/V1/Controllers/PersonApiController.cs
+++ b/PersonApi/V1/Controllers/PersonApiController.cs
@@ -142,7 +142,7 @@ namespace PersonApi.V1.Controllers
             if (int.TryParse(version, out var numericValue))
                 return numericValue;
 
-            return numericValue;
+            return null;
         }
     }
 }

--- a/PersonApi/V1/Controllers/PersonApiController.cs
+++ b/PersonApi/V1/Controllers/PersonApiController.cs
@@ -11,6 +11,7 @@ using PersonApi.V1.Factories;
 using PersonApi.V1.Infrastructure.Exceptions;
 using PersonApi.V1.UseCase.Interfaces;
 using System;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using HeaderConstants = PersonApi.V1.Infrastructure.HeaderConstants;
 
@@ -60,7 +61,11 @@ namespace PersonApi.V1.Controllers
             var person = await _getByIdUseCase.ExecuteAsync(query).ConfigureAwait(false);
             if (null == person) return NotFound(query.Id);
 
-            HttpContext.Response.Headers.Add(HeaderConstants.ETag, person.VersionNumber.ToString());
+            var eTag = string.Empty;
+            if (person.VersionNumber.HasValue)
+                eTag = person.VersionNumber.ToString();
+
+            HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{eTag}\"").Tag);
 
             return Ok(_responseFactory.ToResponse(person));
         }
@@ -100,8 +105,7 @@ namespace PersonApi.V1.Controllers
             var bodyText = await HttpContext.Request.GetRawBodyStringAsync().ConfigureAwait(false);
             var token = _tokenFactory.Create(_contextWrapper.GetContextRequestHeaders(HttpContext));
 
-            string ifMatchString = HttpContext.Request.Headers.GetHeaderValue(HeaderConstants.IfMatch);
-            var ifMatch = int.TryParse(ifMatchString, out int i) ? i : (int?) null;
+            var ifMatch = GetIfMatchFromHeader();
 
             try
             {
@@ -119,6 +123,26 @@ namespace PersonApi.V1.Controllers
             {
                 return Conflict(vncErr.Message);
             }
+        }
+
+        private int? GetIfMatchFromHeader()
+        {
+            var header = HttpContext.Request.Headers.GetHeaderValue(HeaderConstants.IfMatch);
+
+            if (header == null)
+                return null;
+
+            var eTag = EntityTagHeaderValue.TryParse(header, out var entityTagHeaderValue);
+
+            if (entityTagHeaderValue == null)
+                return null;
+
+            var version = entityTagHeaderValue.Tag.Replace("\"", string.Empty);
+
+            if (int.TryParse(version, out var numericValue))
+                return numericValue;
+
+            return numericValue;
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-1597

## Describe this PR

### *What is the problem we're trying to solve*

Currently, the ETag is returned as an integer, e.g. 0, but it needs to be returned surrounded by quotes, e.g. "0" and the provided If-Match header when submitting a PATCH request also needs to be surrounded by quotes

### *What changes have we introduced*

Updated the API to include quotes around the ETag and to parse the If-Match header.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
