### PR TITLE
Bump node versiomn from 14.x to 20.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | bash -
+            curl -sL https://deb.nodesource.com/setup_20.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI


### PR DESCRIPTION
Bump node versiomn from 14.x to 20.x to allow deploy to finish: https://app.circleci.com/pipelines/github/LBHackney-IT/person-api/663/workflows/d210a7b4-cc00-425d-a4e5-95f87790d1ea/jobs/3305