### PR TITLE
increase lambda timeout to 60 secs

### DIFF
--- a/PersonApi/serverless.yml
+++ b/PersonApi/serverless.yml
@@ -22,6 +22,7 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: PersonApi::PersonApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
+    timeout: 60
     environment:
       PERSON_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/person/arn}
       ASPNETCORE_ENVIRONMENT:  ${ssm:/housing-tl/${self:provider.stage}/aspnetcore-environment}


### PR DESCRIPTION
There are a few errors we are getting due to 6 second timeout - this is affecting prod so increasing it to 60 secs