### PR TITLE
Bump JWT core to `1.87.0` for Cognito Token support.

### DIFF
--- a/PersonApi/PersonApi.csproj
+++ b/PersonApi/PersonApi.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.49 -> ... -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - The versions in between have no consequence as the only thing the JWT package is used here for is to inject TokenFactory so that logger could use it to extract user email. The Token schema for email hasn't changed. In fact, the only thing that changed about Token schema is Nbf, Exp, and Iat field types being changed from int to long.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.
 - **These changes do not require immediate deployment**, they merely need to be present within the repo's main branch. This is so those changes would already be there for when anyone would introduce new changes attempting to access Google groups from the token. Without this JWT version bump, any attempted access of Groups within the token would make the API wouldn't fall over.